### PR TITLE
fix: github dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
resolves #25 

PRs from dependabot are being opened to `master` but we want them to go to `dev`. 

This PR adds a target branch as `dev`.